### PR TITLE
AppManagerService.js: Fix call to SAM

### DIFF
--- a/data/AppManagerService.js
+++ b/data/AppManagerService.js
@@ -36,7 +36,7 @@ enyo.kind({
 	restoringApps: [],
 	
 	components: [
-		{name:"listApps", kind: "PalmService", service:"palm://com.palm.applicationManager/", method:"listApps", onSuccess:"gotAppList"},
+		{name:"listApps", kind: "PalmService", service:"palm://com.webos.service.applicationManager/", method:"listApps", onSuccess:"gotAppList"},
 		{name:"getAppInfo", kind: "PalmService", service:"palm://com.palm.applicationManager/", method:"getAppInfo", onSuccess:"gotAppInfo"},
 		
 		{name:"notifyOnChange", kind: "PalmService", service:"palm://com.palm.appinstaller/", method:"notifyOnChange", subscribe:true, onSuccess:"handleAppChanged"},


### PR DESCRIPTION
Fixes: Apr 29 17:20:22 qemux86-64 LunaAppManager[469]: [] [pmlog] <default-lib> LS_NO_METH {"METHOD":"listApps"} Couldn't find method: listApps

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>