### PR TITLE
PowerdService.js: Migrate to com.webos.service.battery

### DIFF
--- a/data/PowerdService.js
+++ b/data/PowerdService.js
@@ -27,7 +27,7 @@ enyo.kind({
 	components: [
 		{kind:enyo.PalmService, name:"batteryStatus", service:"palm://com.palm.bus/signal/", method:"addmatch", subscribe:true, onResponse:"handlePowerNotifications"},
 		{kind:"PalmService", name:"usbdockstatus", service:"palm://com.palm.bus/signal/", method:"addmatch", subscribe:true, onResponse:"handlePowerNotifications"},
-		{kind:"PalmService", name:"chargerStatusQuery", service:"palm://com.palm.power/com/palm/power/", method:"chargerStatusQuery", onResponse:"handleChargerStatus"},
+		{kind:"PalmService", name:"chargerStatusQuery", service:"palm://com.webos.service.battery/com/palm/power/", method:"chargerStatusQuery", onResponse:"handleChargerStatus"},
 
 		{kind:"PalmService", name:"powerKeyPressed", service:"palm://com.palm.bus/signal/", method:"addmatch", subscribe:true, onResponse:"powerOffHandleNotifications"},
 	],


### PR DESCRIPTION
Since we have a dedicated battery service, migrate API call to com.webos.service.battery.